### PR TITLE
Dropdown menus for ingredient Units

### DIFF
--- a/client/src/components/AddNewRecipeForm.js
+++ b/client/src/components/AddNewRecipeForm.js
@@ -174,7 +174,6 @@ class AddNewRecipeForm extends Component {
       const encoded = encodeURIComponent(ev.target.value);
       const url = `${this.state.edamam}/parser?ingr=${encoded}&app_id=${this.state.edamamAppId}&app_key=${this.state.edamamAppKey}`;
       const unitArr = [];
-      console.log(url);
       axios
         .get(url)
         .then(res => {


### PR DESCRIPTION
# Description

Makes Add New Recipe and Edit Recipe forms have dropdown menus for what Units the ingredients are in, with the options being provided by the Edamam API.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
