### PR TITLE
Fixes "cannot read property of undefined" bug

### DIFF
--- a/client/src/components/DisplayOneRecipe.js
+++ b/client/src/components/DisplayOneRecipe.js
@@ -30,7 +30,7 @@ const DisplayRecipeDiv = styled.div`
 
 const DisplayOneRecipe = props => {
   const ratingsFunc = recipe => {
-    if (!recipe.ratings[0]) {
+    if (!recipe.ratings || !recipe.ratings[0]) {
       return 0;
     } else {
       const ratingArr = recipe.ratings.map(rating => rating.rating);
@@ -55,7 +55,9 @@ const DisplayOneRecipe = props => {
             maxRating={5}
             disabled
           />
-          {props.recipe.ratings.length}
+          {props.recipe.ratings
+            ? props.recipe.ratings.length
+            : 0}
         </div>
         <h3>{props.recipe.name}</h3>
         <h4>Description:</h4>


### PR DESCRIPTION
# Description

Keeps site from crashing when displaying list of recipes and a new recipe does not yet have a ".ratings" property.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
