### PR TITLE
fix sidemenu foxus issue

### DIFF
--- a/client/src/components/menus/sideMenu.js
+++ b/client/src/components/menus/sideMenu.js
@@ -16,6 +16,8 @@ class SideMenu extends React.Component {
     // on right menu.
     // without this, URL changes from create/delete recipe won't change the focus of side menu
     // so the focus would be in wrong menu
+    // tried to use some kind of event listener but couldn't find right one
+
     setInterval(() => {
       if (this.state.activeItem !== window.location.pathname) {
         this.setState({ activeItem: window.location.pathname });


### PR DESCRIPTION
# Description

sidemenu focus wrong menu when URL is changed by create/delete recipe

Fixes # (issue)
use setInterval to monitor URL change and set correct focus


## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [x ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- x[ ] There are no merge conflicts
