### PR TITLE
fix edit recipe page not displaying unit 

### DIFF
--- a/client/src/components/EditRecipe.js
+++ b/client/src/components/EditRecipe.js
@@ -83,6 +83,7 @@ class EditRecipeForm extends Component {
     // Populate the unitsList property of each ingredient
     const ingArr = this.props.recipe.ingredients.slice(); // Copy ingredients from the db without unitsLists
     for (let i = 0; i < ingArr.length; i++) {
+      if (!ingArr[i].unit) ingArr[i].unit = 'Whole';
       if (ingArr[i].name !== '') {
         // To avoid pinging the API with empty string queries
         ingArr[i].unitsList = []; // Make sure there is a unitsList to add to

--- a/client/src/components/EditRecipe.js
+++ b/client/src/components/EditRecipe.js
@@ -417,6 +417,20 @@ class EditRecipeForm extends Component {
       let ingredientRows = [];
       for (let i = 0; i < this.state.numIngredients; i++) {
         const unitOptions = [];
+
+        // imported recipes might not have correct unit and do not have default unit displayed
+        // to fix this, check if unit is included in unitList and if not add unit to unitsList
+        if (
+          this.state.ingredients[i].unitsList.indexOf(
+            this.state.ingredients[i].unit
+          ) < 0
+        ) {
+          unitOptions.push({
+            value: this.state.ingredients[i].unit,
+            text: this.state.ingredients[i].unit
+          });
+        }
+
         this.state.ingredients[i].unitsList.map(unit =>
           unitOptions.push({
             value: unit,


### PR DESCRIPTION
# Description

fixed a bug that sometimes edit recipe not displaying unit.
this happens to imported recipes that doesn't have compatible units

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [x ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x ] There are no merge conflicts
