### PR TITLE
fix showing incorrect nutrition when top rated is clicked + crashing add recipe page when ingredient is 0

### DIFF
--- a/client/src/components/AddNewRecipeForm.js
+++ b/client/src/components/AddNewRecipeForm.js
@@ -167,13 +167,15 @@ class AddNewRecipeForm extends Component {
   };
 
   deleteIngredient = (ev, rowNum) => {
-    let ingCopy = this.state.ingredients;
-    const newIngNum = this.state.numIngredients - 1;
-    ingCopy.splice(rowNum, 1);
-    this.setState({
-      numIngredients: newIngNum,
-      ingredients: ingCopy
-    });
+    if (this.state.numIngredients > 1) {
+      let ingCopy = this.state.ingredients;
+      const newIngNum = this.state.numIngredients - 1;
+      ingCopy.splice(rowNum, 1);
+      this.setState({
+        numIngredients: newIngNum,
+        ingredients: ingCopy
+      });
+    }
   };
 
   submitHandler = async ev => {
@@ -440,11 +442,19 @@ class AddNewRecipeForm extends Component {
             name='delete'
             size='large'
             onClick={ev => this.deleteIngredient(ev, i)}
-            style={{
-              cursor: 'pointer',
-              color: ourColors.buttonColor,
-              marginTop: '8px'
-            }}
+            style={
+              this.state.numIngredients > 1
+                ? {
+                    cursor: 'pointer',
+                    color: ourColors.buttonColor,
+                    marginTop: '8px'
+                  }
+                : {
+                    cursor: 'not-allowed',
+                    color: ourColors.buttonColor,
+                    marginTop: '8px'
+                  }
+            }
           />
         </Form.Group>
       );

--- a/client/src/components/AddNewRecipeForm.js
+++ b/client/src/components/AddNewRecipeForm.js
@@ -92,7 +92,8 @@ class AddNewRecipeForm extends Component {
     if (e.target.name === 'numIngredients') {
       // numIngredients needs certain logic
       let prevNumIng;
-      const value = e.target.value; // declared since lost in async setState
+      let value = e.target.value; // declared since lost in async setState
+      if (value < 1) value = 1; // must have at least 1 ingredient
       this.setState(prevState => {
         prevNumIng = prevState.numIngredients; // getting prevNumIng for later use
         if (prevNumIng > value) {

--- a/client/src/components/AddNewRecipeForm.js
+++ b/client/src/components/AddNewRecipeForm.js
@@ -93,7 +93,7 @@ class AddNewRecipeForm extends Component {
       // numIngredients needs certain logic
       let prevNumIng;
       let value = e.target.value; // declared since lost in async setState
-      if (value < 1) value = 1; // must have at least 1 ingredient
+      if (value < 1) value = 1; // recipe must have at least 1 ingredient
       this.setState(prevState => {
         prevNumIng = prevState.numIngredients; // getting prevNumIng for later use
         if (prevNumIng > value) {
@@ -167,6 +167,7 @@ class AddNewRecipeForm extends Component {
   };
 
   deleteIngredient = (ev, rowNum) => {
+    // Recipe must have at least 1 ingredient.  Can not delete if there is only one ingredient
     if (this.state.numIngredients > 1) {
       let ingCopy = this.state.ingredients;
       const newIngNum = this.state.numIngredients - 1;
@@ -443,6 +444,8 @@ class AddNewRecipeForm extends Component {
             size='large'
             onClick={ev => this.deleteIngredient(ev, i)}
             style={
+              // if there is only one ingredient left, disable delete ingredient button
+              // there should be at least 1 ingredient
               this.state.numIngredients > 1
                 ? {
                     cursor: 'pointer',

--- a/client/src/components/EditRecipe.js
+++ b/client/src/components/EditRecipe.js
@@ -84,6 +84,7 @@ class EditRecipeForm extends Component {
     // Populate the unitsList property of each ingredient
     const ingArr = this.props.recipe.ingredients.slice(); // Copy ingredients from the db without unitsLists
     for (let i = 0; i < ingArr.length; i++) {
+      // if unit is null, assign Whole as default
       if (!ingArr[i].unit) ingArr[i].unit = 'Whole';
       if (ingArr[i].name !== '') {
         // To avoid pinging the API with empty string queries

--- a/client/src/components/SingleRecipe.js
+++ b/client/src/components/SingleRecipe.js
@@ -53,6 +53,7 @@ class SingleRecipe extends React.Component {
   componentDidUpdate(prevProps) {
     if (prevProps.match.params.id !== this.props.match.params.id) {
       this.props.getRecipe(this.props.match.params.id);
+      this.getNutrition();
     }
   }
 


### PR DESCRIPTION
# Description

fixes 2 issues
- showing incorrect nutrition --> updated nutrition when top rated recipe is clicked.
- add recipe page crashing --> it happens when there is no ingredient.  I fixed it so there has to be at least 1 ingredient.  User can not set num of ingredient to 0 and can not delete a ingredient by clicking X icon if there is only one ingredient

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Change status
- [ ] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x] There are no merge conflicts
